### PR TITLE
asignación del medidor al stand luego del paso de preparación

### DIFF
--- a/src/app/components/major-steps/preparation-major-step/preparation-major-step.component.ts
+++ b/src/app/components/major-steps/preparation-major-step/preparation-major-step.component.ts
@@ -7,9 +7,18 @@ import { EssayStep } from '../../../models/business/interafces/essay-step.model'
 import { StepStatus } from '../../../models/business/enums/step-status.model';
 import { RunEssayService } from '../../../services/run-essay.service';
 import { EssayTemplateStep } from '../../../models/business/database/essay-template-step.model';
-import { Observable, take, tap } from 'rxjs';
+import { Observable, take, tap, first, map } from 'rxjs';
 import { MajorStepsDirector } from '../../../models/business/class/major-steps-director.model';
 import { APP_CONFIG } from '../../../../environments/environment';
+import { DatabaseService } from '../../../services/database.service';
+import {
+  Meter,
+  MeterDbTableContext,
+} from '../../../models/business/database/meter.model';
+import { RelationsManager } from '../../../models/core/relations-manager.model';
+import { FormArray } from '@angular/forms';
+import { AbstractFormGroup } from '../../../models/core/abstract-form-group.model';
+import { Stand } from '../../../models/business/interafces/stand.model';
 
 @Component({
   selector: 'app-preparation-major-step',
@@ -24,7 +33,10 @@ export class PreparationMajorStepComponent implements AfterViewInit {
 
   readonly StepStatus = StepStatus;
 
-  constructor(private readonly runEssayService: RunEssayService) {}
+  constructor(
+    private readonly runEssayService: RunEssayService,
+    private readonly dbServiceMeter: DatabaseService<Meter>
+  ) {}
 
   get isRunEssayFormValid(): boolean {
     return this.runEssayService.runEssayForm.valid;
@@ -59,12 +71,66 @@ export class PreparationMajorStepComponent implements AfterViewInit {
     );
   }
 
+  /**
+   * En base a los meter_id seleccionados, asignar a cada stand la informacion del modelo de medidor
+   */
+  assignMetersToStands$(): Observable<EssayStep> {
+    // Obtener los medidores para asignarlos a los stands del preparation step
+    return this.dbServiceMeter
+      .getTable$(MeterDbTableContext.tableName, {
+        relations: MeterDbTableContext.foreignTables,
+      })
+      .pipe(
+        first(),
+        map(({ rows, relations }) =>
+          RelationsManager.mergeRelationsIntoRows<Meter>(
+            rows,
+            relations,
+            MeterDbTableContext.foreignTables
+          )
+        ),
+        map((meters) => {
+          if (!this.preparationStep) {
+            throw new Error('Paso de preparación no encontrado');
+          }
+          const preparationEssayStepForm = this.runEssayService.getEssayStep(
+            this.preparationStep.id
+          );
+          (
+            preparationEssayStepForm.get('form_control_raw') as FormArray<
+              AbstractFormGroup<Stand>
+            >
+          ).controls.forEach((standControl) => {
+            const meter = meters.find(
+              ({ id }) => standControl.getRawValue().meter_id === id
+            );
+            if (meter && standControl.controls.meter_id) {
+              standControl.get('foreign')?.setValue(
+                {
+                  meter: {
+                    ...meter,
+                    label: `${meter.foreign.brand.name} - ${meter.model}`,
+                  },
+                },
+                { emitEvent: false }
+              );
+            }
+          });
+          return this.preparationStep;
+        })
+      );
+  }
+
   continue(): void {
     if (!this.preparationStep) {
       return;
     }
-    this.markVerifiedStep(this.preparationStep);
-    this.runEssayService.nextMajorStep();
+    this.assignMetersToStands$().subscribe({
+      next: (preparationStep) => {
+        this.markVerifiedStep(preparationStep);
+        this.runEssayService.nextMajorStep();
+      },
+    });
   }
 
   private skip(): void {

--- a/src/app/features/run-essay/run-essay.component.ts
+++ b/src/app/features/run-essay/run-essay.component.ts
@@ -15,7 +15,6 @@ import {
   switchMap,
   takeUntil,
   tap,
-  first,
 } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { DatabaseService } from '../../services/database.service';
@@ -37,11 +36,6 @@ import { WhereKind, WhereOperator } from '../../models/core/database.model';
 import { RelationsManager } from '../../models/core/relations-manager.model';
 import { RunEssayService } from '../../services/run-essay.service';
 import { APP_CONFIG } from '../../../environments/environment';
-import {
-  Meter,
-  MeterDbTableContext,
-} from '../../models/business/database/meter.model';
-import { PreparationEssayStep } from '../../models/business/interafces/steps/preparation-step.model';
 
 @Component({
   selector: 'app-run-essay',
@@ -61,7 +55,6 @@ export class RunEssayComponent implements OnInit, OnDestroy {
     private readonly fb: FormBuilder,
     private readonly dbServiceEssayTemplate: DatabaseService<EssayTemplate>,
     private readonly dbServiceEssayTemplateStep: DatabaseService<EssayTemplateStep>,
-    private readonly dbServiceMeter: DatabaseService<Meter>,
     private readonly route: ActivatedRoute,
     private readonly navigationService: NavigationService,
     public readonly runEssayService: RunEssayService
@@ -141,40 +134,6 @@ export class RunEssayComponent implements OnInit, OnDestroy {
         ),
         map((essayTemplateSteps) =>
           essayTemplateSteps.sort((a, b) => a.order - b.order)
-        ),
-        // Obtener los medidores para asignarlos a los stands del preparation step
-        switchMap((essayTemplateSteps) =>
-          this.dbServiceMeter
-            .getTable$(MeterDbTableContext.tableName, {
-              relations: MeterDbTableContext.foreignTables,
-            })
-            .pipe(
-              first(),
-              map(({ rows, relations }) =>
-                RelationsManager.mergeRelationsIntoRows<Meter>(
-                  rows,
-                  relations,
-                  MeterDbTableContext.foreignTables
-                )
-              ),
-              tap((meters) => {
-                // asignar los medidores al preparation step
-                const preprationStep: PreparationEssayStep =
-                  essayTemplateSteps[0] as PreparationEssayStep;
-                preprationStep.form_control_raw.forEach((stand) => {
-                  const meter = meters.find(({ id }) => stand.meter_id === id);
-                  if (meter) {
-                    stand.foreign = {
-                      meter: {
-                        ...meter,
-                        label: `${meter.foreign.brand.name} - ${meter.model}`,
-                      },
-                    };
-                  }
-                });
-              }),
-              map(() => essayTemplateSteps)
-            )
         ),
         tap((essayTemplateSteps) =>
           this.runEssayService.buildSteps(essayTemplateSteps)


### PR DESCRIPTION
En la preparación tenemos "Stands" o "Puestos".

**Antes**

Al ejecutar un ensayo se entra en el feature "run essay" donde se asignaba los medidores (meters) a los puestos (stands). 
El bug es que durante el paso de preparación el medidor asignado al stand puede cambiar....

**Ahora**

Se asigna el medidor al stand, cunado se presiona "continuar" en el paso de preparación, es decir que el medidor asignado al stand ya no puede cambiar luego de este paso.