### PR TITLE
limpiesa de valores en resultado indefinido

### DIFF
--- a/src/app/components/steps/run-steps/boot-test-run/boot-test-run.component.ts
+++ b/src/app/components/steps/run-steps/boot-test-run/boot-test-run.component.ts
@@ -72,7 +72,11 @@ export class BootTestRunComponent extends TestRunComponent<BootTestEssayStep> im
         // update measuredPulses
         this.getActiveStands().forEach(({ index: standIndex }, resultIndex) => {
             const result: CommandResultResponse = results[resultIndex];
+            // si no se recibe resultado, se limpia el valor actual
             if (result === undefined) {
+                this.runEssayService
+                    .getStandResult<BootTestStandResult>(this.currentStep.id, standIndex)
+                    .patchValue({ measuredPulses: undefined });
                 return;
             }
             this.runEssayService

--- a/src/app/components/steps/run-steps/contrast-test-run/contrast-test-run.component.ts
+++ b/src/app/components/steps/run-steps/contrast-test-run/contrast-test-run.component.ts
@@ -54,11 +54,13 @@ export class ContrastTestRunComponent extends TestRunComponent<ContrastTestEssay
     onCalculatorResults(results: CommandResultResponse[]): void {
         // update measured error
         this.getActiveStands().forEach(({ index: standIndex }, resultIndex) => {
+            const stand = this.runEssayService.getStandResult<ContrastTestStandResult>(this.currentStep.id, standIndex);
             const result: CommandResultResponse = results[resultIndex];
+            // si no se recibe resultado, se limpia el valor actual
             if (result === undefined) {
+                stand.patchValue({ measuredError: undefined });
                 return;
             }
-            const stand = this.runEssayService.getStandResult<ContrastTestStandResult>(this.currentStep.id, standIndex);
             // bloqueo de resultado actual según modo de ejecución
             if (
                 this.stepRunMode === StepRunMode.finalResultLock &&

--- a/src/app/components/steps/run-steps/vacuum-test-run/vacuum-test-run.component.ts
+++ b/src/app/components/steps/run-steps/vacuum-test-run/vacuum-test-run.component.ts
@@ -61,7 +61,11 @@ export class VacuumTestRunComponent extends TestRunComponent<VacuumTestEssayStep
         // update measuredPulses
         this.getActiveStands().forEach(({ index: standIndex }, resultIndex) => {
             const result: CommandResultResponse = results[resultIndex];
+            // si no se recibe resultado, se limpia el valor actual
             if (result === undefined) {
+                this.runEssayService
+                    .getStandResult<VacuumTestStandResult>(this.currentStep.id, standIndex)
+                    .patchValue({ measuredPulses: undefined });
                 return;
             }
             this.runEssayService


### PR DESCRIPTION
Limpiar el valor que se muestra como resultado para un puesto, si el valor que llega desde la máquina es undefined. Esto puede suceder por ejemplo si el usuario toca el botón para resetear el puesto en la máquina.